### PR TITLE
6 restructuring

### DIFF
--- a/file/delete.go
+++ b/file/delete.go
@@ -26,6 +26,7 @@ func DeleteHandler(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{
 			"message": "minio delete error",
+			"error":   err.Error(),
 		})
 	}
 	return c.JSON(result)

--- a/file/delete.go
+++ b/file/delete.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func Delete(objectName string) (fiber.Map, error) {
+func delete(objectName string) (fiber.Map, error) {
 	ctx := context.Background()
 
 	err := MinioClient.RemoveObject(ctx, BucketName, objectName, minio.RemoveObjectOptions{})
@@ -18,4 +18,15 @@ func Delete(objectName string) (fiber.Map, error) {
 		"message": "delete success",
 		"success": true,
 	}, nil
+}
+
+func DeleteHandler(c *fiber.Ctx) error {
+	fileName := c.Params("filename")
+	result, err := delete(fileName)
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{
+			"message": "minio delete error",
+		})
+	}
+	return c.JSON(result)
 }

--- a/file/download.go
+++ b/file/download.go
@@ -18,7 +18,7 @@ func download(objectName string) (*minio.Object, minio.ObjectInfo, string, error
 
 	object, err := MinioClient.GetObject(context.Background(), BucketName, decodedObjectName, minio.GetObjectOptions{})
 	if err != nil {
-		log.Println(err)
+		log.Printf("Error getting object: %s", err)
 		return nil, minio.ObjectInfo{}, "", err
 	}
 	stat, nil := object.Stat()
@@ -33,7 +33,7 @@ func DownloadHandler(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{
 			"message": "minio download error",
-			"err":     err.Error(),
+			"error":   err.Error(),
 		})
 	}
 

--- a/file/download.go
+++ b/file/download.go
@@ -5,10 +5,11 @@ import (
 	"log"
 	"net/url"
 
+	"github.com/gofiber/fiber/v2"
 	"github.com/minio/minio-go/v7"
 )
 
-func Download(objectName string) (*minio.Object, minio.ObjectInfo, string, error) {
+func download(objectName string) (*minio.Object, minio.ObjectInfo, string, error) {
 	decodedObjectName, err := url.QueryUnescape(objectName)
 	if err != nil {
 		log.Printf("Error decoding object name: %s", err)
@@ -24,4 +25,22 @@ func Download(objectName string) (*minio.Object, minio.ObjectInfo, string, error
 	log.Printf("Successfully downloaded %s\n", decodedObjectName)
 
 	return object, stat, decodedObjectName, nil
+}
+
+func DownloadHandler(c *fiber.Ctx) error {
+	fileName := c.Params("filename")
+	object, objectInfo, fileName, err := download(fileName)
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{
+			"message": "minio download error",
+			"err":     err.Error(),
+		})
+	}
+
+	c.Response().Header.Set("Content-Type", objectInfo.ContentType)
+	c.Response().Header.Set("Content-Disposition", "attachment; filename="+fileName)
+	c.Response().Header.Set("Accept-Ranges", "bytes")
+	defer object.Close()
+
+	return c.SendStream(object)
 }

--- a/file/list.go
+++ b/file/list.go
@@ -15,7 +15,7 @@ type ResultStruct struct {
 	Expires      string
 }
 
-func List() (fiber.Map, error) {
+func list() (fiber.Map, error) {
 
 	ctx := context.Background()
 	objectCh := MinioClient.ListObjects(ctx, BucketName, minio.ListObjectsOptions{})
@@ -34,4 +34,14 @@ func List() (fiber.Map, error) {
 		"success": true,
 		"list":    result,
 	}, nil
+}
+
+func ListHandler(c *fiber.Ctx) error {
+	result, err := list()
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{
+			"message": "minio list error",
+		})
+	}
+	return c.JSON(result)
 }

--- a/file/list.go
+++ b/file/list.go
@@ -23,7 +23,7 @@ func list() (fiber.Map, error) {
 	var result []ResultStruct
 	for object := range objectCh {
 		if object.Err != nil {
-			return fiber.Map{"message": "list failed", "success": false, "list": result}, object.Err
+			return nil, object.Err
 		}
 		result = append(result, ResultStruct{Name: object.Key, LastModified: object.LastModified.Format(time.RFC3339),
 			Size: object.Size, Expires: object.Expires.Format(time.RFC3339)})
@@ -41,6 +41,7 @@ func ListHandler(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{
 			"message": "minio list error",
+			"error":   err.Error(),
 		})
 	}
 	return c.JSON(result)

--- a/file/upload.go
+++ b/file/upload.go
@@ -38,8 +38,8 @@ func UploadHandler(c *fiber.Ctx) error {
 	data, err := c.FormFile("file")
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": true,
-			"msg":   err.Error(),
+			"message": "Please upload a file (multipart/form-data)",
+			"error":   err.Error(),
 		})
 	}
 
@@ -47,8 +47,8 @@ func UploadHandler(c *fiber.Ctx) error {
 	buffer, err := data.Open()
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"status": "can't chage file to buffer",
-			"error":  err.Error(),
+			"message": "can't chage file to buffer",
+			"error":   err.Error(),
 		})
 	}
 	defer buffer.Close()
@@ -62,8 +62,8 @@ func UploadHandler(c *fiber.Ctx) error {
 
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{
-			"status": "minio upload error",
-			"error":  err.Error(),
+			"message": "minio upload error",
+			"error":   err.Error(),
 		})
 	}
 	return c.JSON(result)

--- a/file/upload.go
+++ b/file/upload.go
@@ -11,7 +11,7 @@ import (
 	"github.com/minio/minio-go/v7"
 )
 
-func Upload(objectName, contentType string, fileBuffer io.Reader, fileSize int64) (fiber.Map, error) {
+func upload(objectName, contentType string, fileBuffer io.Reader, fileSize int64) (fiber.Map, error) {
 	ctx := context.Background()
 
 	// Upload the zip file with FPutObject
@@ -32,4 +32,39 @@ func Upload(objectName, contentType string, fileBuffer io.Reader, fileSize int64
 		"delete_url":   fmt.Sprintf("%s/delete/%s", os.Getenv("BACKEND_BASEURL"), info.Key),
 		"download_url": fmt.Sprintf("%s/dl/%s", os.Getenv("BACKEND_BASEURL"), info.Key),
 	}, nil
+}
+
+func UploadHandler(c *fiber.Ctx) error {
+	data, err := c.FormFile("file")
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": true,
+			"msg":   err.Error(),
+		})
+	}
+
+	// Get Buffer from file
+	buffer, err := data.Open()
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"status": "can't chage file to buffer",
+			"error":  err.Error(),
+		})
+	}
+	defer buffer.Close()
+
+	objectName := data.Filename
+	fileBuffer := buffer
+	contentType := data.Header["Content-Type"][0]
+	fileSize := data.Size
+
+	result, err := upload(objectName, contentType, fileBuffer, fileSize)
+
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{
+			"status": "minio upload error",
+			"error":  err.Error(),
+		})
+	}
+	return c.JSON(result)
 }

--- a/main.go
+++ b/main.go
@@ -37,84 +37,10 @@ func main() {
 		})
 	})
 
-	app.Post("/upload", upload)
-	app.Get("/list", list)
-	app.Delete("/del/:filename", delete)
-	app.Get("/dl/:filename", download)
+	app.Post("/upload", file.UploadHandler)
+	app.Get("/list", file.ListHandler)
+	app.Delete("/del/:filename", file.DeleteHandler)
+	app.Get("/dl/:filename", file.DownloadHandler)
 
 	log.Fatal(app.Listen(":5000"))
-}
-
-func upload(c *fiber.Ctx) error {
-	data, err := c.FormFile("file")
-	if err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": true,
-			"msg":   err.Error(),
-		})
-	}
-
-	// Get Buffer from file
-	buffer, err := data.Open()
-	if err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"status": "can't chage file to buffer",
-			"error":  err.Error(),
-		})
-	}
-	defer buffer.Close()
-
-	objectName := data.Filename
-	fileBuffer := buffer
-	contentType := data.Header["Content-Type"][0]
-	fileSize := data.Size
-
-	result, err := file.Upload(objectName, contentType, fileBuffer, fileSize)
-
-	if err != nil {
-		return c.Status(500).JSON(fiber.Map{
-			"status": "minio upload error",
-			"error":  err.Error(),
-		})
-	}
-	return c.JSON(result)
-}
-
-func list(c *fiber.Ctx) error {
-	result, err := file.List()
-	if err != nil {
-		return c.Status(500).JSON(fiber.Map{
-			"message": "minio list error",
-		})
-	}
-	return c.JSON(result)
-}
-
-func delete(c *fiber.Ctx) error {
-	fileName := c.Params("filename")
-	result, err := file.Delete(fileName)
-	if err != nil {
-		return c.Status(500).JSON(fiber.Map{
-			"message": "minio delete error",
-		})
-	}
-	return c.JSON(result)
-}
-
-func download(c *fiber.Ctx) error {
-	fileName := c.Params("filename")
-	object, objectInfo, fileName, err := file.Download(fileName)
-	if err != nil {
-		return c.Status(500).JSON(fiber.Map{
-			"message": "minio download error",
-			"err":     err.Error(),
-		})
-	}
-
-	c.Response().Header.Set("Content-Type", objectInfo.ContentType)
-	c.Response().Header.Set("Content-Disposition", "attachment; filename="+fileName)
-	c.Response().Header.Set("Accept-Ranges", "bytes")
-	defer object.Close()
-
-	return c.SendStream(object)
 }


### PR DESCRIPTION
main.go에 존재하던 리퀘스트 핸들러들을 전부 file package로 이동하여 코드 수정이 용이하게 변경

규칙성이 없던 error 메세지를 "message" 필드와 "error" 필드로 통일함